### PR TITLE
print stack trace if access-token is not provided

### DIFF
--- a/src/clj_rollbar/core.clj
+++ b/src/clj_rollbar/core.clj
@@ -123,9 +123,11 @@
 (defn report-exception
   "Reports an exception at the 'error' level"
   [access-token environment exception & {:keys [request user-id]}]
-  (let [data-map (base-data environment "error")
-        trace-map {:body {:trace (build-trace
-                                  (parse-exception exception))}}
-        request-map (if request (request-data request user-id) {})
-        data-maps [data-map trace-map request-map]]
-    (send-payload (build-payload access-token data-maps))))
+  (if (empty? access-token)
+    (.printStackTrace exception)
+    (let [data-map (base-data environment "error")
+          trace-map {:body {:trace (build-trace
+                                    (parse-exception exception))}}
+          request-map (if request (request-data request user-id) {})
+          data-maps [data-map trace-map request-map]]
+      (send-payload (build-payload access-token data-maps)))))


### PR DESCRIPTION
I keep my rollbar access token in an environment variable. This way, I can configure staging, production, etc. to send exceptions to the proper rollbar project.

But, when I'm working on my local machine, I would prefer to print the stack traces as normal. This is so I do not have to provide an environment variable locally, nor do I need to access my exceptions on rollbar.com. It's much simpler to view the stack traces in my logs as opposed to accessing them on rollbar.com. This also helps when no internet connection is available e.g. working on a plane.

Checking for an `access-token` allows me to not have to put an `if` in my application code to check `development?` or do the check for the `access-token`; this should be the responsibility of `clj-rollbar`.